### PR TITLE
Pass in an object of query and props to useSanityQuery

### DIFF
--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -20,7 +20,7 @@ export const getStaticProps = async (context) => ({
 export default function Home(props) {
     const {
         data: { site, landingPage },
-    } = useSanityQuery(query, props)
+    } = useSanityQuery({query, props})
 
     return (
         <div>


### PR DESCRIPTION
Currently, running the project throws an error `cannot find params of undefined`.
This is because `sanityStaticProps` expects an object, but 2 arguments are passed in instead.